### PR TITLE
fix: references CurrentGraph

### DIFF
--- a/cmd/zgraph/main.go
+++ b/cmd/zgraph/main.go
@@ -15,7 +15,10 @@
 package main
 
 import (
+	"bufio"
+	"context"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/vescale/zgraph"
@@ -56,5 +59,20 @@ func interact(session *session.Session) {
 	fmt.Println("Welcome to zGraph interactive command line.")
 	for {
 		// TODO: scan text and execute it.
+		reader := bufio.NewReader(os.Stdin)
+		text, err := reader.ReadString('\n')
+		// if something goes wrong, just read newline.
+		if err != nil {
+			fmt.Println(err)
+			continue
+		}
+		execute, err := session.Execute(context.Background(), text)
+		// is something goes wrong, just show error, and read newline.
+		if err != nil {
+			fmt.Println(err)
+			continue
+		}
+		// TODO: show result better
+		fmt.Println(execute)
 	}
 }

--- a/compiler/preprocess.go
+++ b/compiler/preprocess.go
@@ -16,6 +16,7 @@ package compiler
 
 import (
 	"github.com/pingcap/errors"
+	"github.com/vescale/zgraph/catalog"
 	"github.com/vescale/zgraph/meta"
 	"github.com/vescale/zgraph/parser/ast"
 	"github.com/vescale/zgraph/stmtctx"
@@ -91,13 +92,7 @@ func (p *Preprocess) checkCreateLabelStmt(stmt *ast.CreateLabelStmt) {
 	}
 
 	if !stmt.IfNotExists {
-		graphName := p.sc.CurrentGraph()
-		if graphName == "" {
-			p.err = ErrGraphNotChosen
-			return
-		}
-
-		graph := p.sc.Catalog().Graph(graphName)
+		graph := p.sc.CurrentGraph()
 		if graph == nil {
 			p.err = meta.ErrGraphNotExists
 			return
@@ -116,13 +111,7 @@ func (p *Preprocess) checkCreateIndexStmt(stmt *ast.CreateIndexStmt) {
 		return
 	}
 
-	graphName := p.sc.CurrentGraph()
-	if graphName == "" {
-		p.err = ErrGraphNotChosen
-		return
-	}
-
-	graph := p.sc.Catalog().Graph(graphName)
+	graph := p.sc.CurrentGraph()
 	if graph == nil {
 		p.err = meta.ErrGraphNotExists
 		return
@@ -152,13 +141,7 @@ func (p *Preprocess) checkDropGraphStmt(stmt *ast.DropGraphStmt) {
 }
 
 func (p *Preprocess) checkDropLabelStmt(stmt *ast.DropLabelStmt) {
-	graphName := p.sc.CurrentGraph()
-	if graphName == "" {
-		p.err = ErrGraphNotChosen
-		return
-	}
-
-	graph := p.sc.Catalog().Graph(graphName)
+	graph := p.sc.CurrentGraph()
 	if graph == nil && !stmt.IfExists {
 		p.err = meta.ErrGraphNotExists
 		return
@@ -171,13 +154,7 @@ func (p *Preprocess) checkDropLabelStmt(stmt *ast.DropLabelStmt) {
 }
 
 func (p *Preprocess) checkDropIndexStmt(stmt *ast.DropIndexStmt) {
-	graphName := p.sc.CurrentGraph()
-	if graphName == "" {
-		p.err = ErrGraphNotChosen
-		return
-	}
-
-	graph := p.sc.Catalog().Graph(graphName)
+	graph := p.sc.CurrentGraph()
 	if graph == nil && !stmt.IfExists {
 		p.err = meta.ErrGraphNotExists
 		return
@@ -223,10 +200,12 @@ func (p *Preprocess) checkInsertStmt(stmt *ast.InsertStmt) {
 		}
 		intoGraph = stmt.IntoGraphName.L
 	}
+	var graph *catalog.Graph
 	if intoGraph == "" {
-		intoGraph = p.sc.CurrentGraph()
+		graph = p.sc.CurrentGraph()
+	} else {
+		graph = p.sc.Catalog().Graph(intoGraph)
 	}
-	graph := p.sc.Catalog().Graph(intoGraph)
 	if graph == nil {
 		p.err = errors.Annotatef(meta.ErrGraphNotExists, "graph: %s", intoGraph)
 		return

--- a/compiler/property_preparation.go
+++ b/compiler/property_preparation.go
@@ -38,7 +38,7 @@ type PropertyPreparation struct {
 func NewPropertyPreparation(sc *stmtctx.Context) *PropertyPreparation {
 	return &PropertyPreparation{
 		sc:    sc,
-		graph: sc.Catalog().Graph(sc.CurrentGraph()),
+		graph: sc.CurrentGraph(),
 	}
 }
 

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -145,8 +145,7 @@ func (e *DDLExec) dropGraph(m *meta.Meta, stmt *ast.DropGraphStmt) (*catalog.Pat
 }
 
 func (e *DDLExec) createLabel(m *meta.Meta, stmt *ast.CreateLabelStmt) (*catalog.Patch, error) {
-	graphName := e.sc.CurrentGraph()
-	graph := e.sc.Catalog().Graph(graphName)
+	graph := e.sc.CurrentGraph()
 	if graph == nil {
 		return nil, meta.ErrGraphNotExists
 	}
@@ -184,8 +183,7 @@ func (e *DDLExec) createLabel(m *meta.Meta, stmt *ast.CreateLabelStmt) (*catalog
 }
 
 func (e *DDLExec) dropLabel(m *meta.Meta, stmt *ast.DropLabelStmt) (*catalog.Patch, error) {
-	graphName := e.sc.CurrentGraph()
-	graph := e.sc.Catalog().Graph(graphName)
+	graph := e.sc.CurrentGraph()
 	if graph == nil {
 		return nil, meta.ErrGraphNotExists
 	}

--- a/executor/simple_test.go
+++ b/executor/simple_test.go
@@ -45,7 +45,7 @@ func TestSimpleExec(t *testing.T) {
 		{
 			query: "use g1",
 			check: func(s *session.Session) {
-				assert.Equal("g1", s.StmtContext().CurrentGraph())
+				assert.Equal("g1", s.StmtContext().CurrentGraphName())
 			},
 		},
 	}

--- a/planner/plan_builder.go
+++ b/planner/plan_builder.go
@@ -99,10 +99,12 @@ func (b *Builder) buildInsert(stmt *ast.InsertStmt) error {
 	if !stmt.IntoGraphName.IsEmpty() {
 		intoGraph = stmt.IntoGraphName.L
 	}
+	var graph *catalog.Graph
 	if intoGraph == "" {
-		intoGraph = b.sc.CurrentGraph()
+		graph = b.sc.CurrentGraph()
+	} else {
+		graph = b.sc.Catalog().Graph(intoGraph)
 	}
-	graph := b.sc.Catalog().Graph(intoGraph)
 	if graph == nil {
 		return errors.Annotatef(meta.ErrGraphNotExists, "graph %s", intoGraph)
 	}
@@ -264,10 +266,12 @@ func (b *Builder) buildMatch(matches []*ast.MatchClause) (LogicalPlan, error) {
 	var subgraphs []*Subgraph
 	for _, m := range matches {
 		graphName := m.Graph.L
+		var graph *catalog.Graph
 		if graphName == "" {
-			graphName = b.sc.CurrentGraph()
+			graph = b.sc.CurrentGraph()
+		} else {
+			graph = b.sc.Catalog().Graph(graphName)
 		}
-		graph := b.sc.Catalog().Graph(graphName)
 		if graph == nil {
 			return nil, errors.Annotatef(meta.ErrGraphNotExists, "graph %s", graphName)
 		}

--- a/stmtctx/context.go
+++ b/stmtctx/context.go
@@ -81,13 +81,12 @@ func (sc *Context) Catalog() *catalog.Catalog {
 	return sc.catalog
 }
 
-// CurrentGraph returns the current chosen graph name.
-// change: 2022-12-12 11:20:04 CurrentGraph returns the current chosen catalog graph.
+// CurrentGraph returns the current chosen catalog graph
 func (sc *Context) CurrentGraph() *catalog.Graph {
 	sc.mu.RLock()
 	defer sc.mu.RUnlock()
 
-	// return sc.mu.currentGraph
+	// return catalog.Graph
 	return sc.Catalog().Graph(sc.mu.currentGraph)
 }
 
@@ -97,4 +96,12 @@ func (sc *Context) SetCurrentGraph(graphName string) {
 	defer sc.mu.Unlock()
 
 	sc.mu.currentGraph = strings.ToLower(graphName)
+}
+
+// CurrentGraphName returns the current chosen graph name.
+func (sc *Context) CurrentGraphName() string {
+	sc.mu.RLock()
+	defer sc.mu.RUnlock()
+
+	return sc.mu.currentGraph
 }

--- a/stmtctx/context.go
+++ b/stmtctx/context.go
@@ -82,11 +82,13 @@ func (sc *Context) Catalog() *catalog.Catalog {
 }
 
 // CurrentGraph returns the current chosen graph name.
-func (sc *Context) CurrentGraph() string {
+// change: 2022-12-12 11:20:04 CurrentGraph returns the current chosen catalog graph.
+func (sc *Context) CurrentGraph() *catalog.Graph {
 	sc.mu.RLock()
 	defer sc.mu.RUnlock()
 
-	return sc.mu.currentGraph
+	// return sc.mu.currentGraph
+	return sc.Catalog().Graph(sc.mu.currentGraph)
 }
 
 // SetCurrentGraph changes the current graph name.


### PR DESCRIPTION
The previous fixes prevented functions that referenced CurrentGraph functions from compiling, this commit modifies them and allows them to compile successfully.