### PR TITLE
sync.WaitGroup replaced by a https://github.com/sourcegraph/conc

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -42,7 +42,7 @@ type Session struct {
 	mu       sync.Mutex
 	id       int64
 	sc       *stmtctx.Context
-	wg       https://github.com/sourcegraph/conc
+	wg       conc.WaitGroup
 	store    kv.Storage
 	catalog  *catalog.Catalog
 	closed   atomic.Bool

--- a/session/session.go
+++ b/session/session.go
@@ -42,7 +42,7 @@ type Session struct {
 	mu       sync.Mutex
 	id       int64
 	sc       *stmtctx.Context
-	wg       sync.WaitGroup
+	wg       https://github.com/sourcegraph/conc
 	store    kv.Storage
 	catalog  *catalog.Catalog
 	closed   atomic.Bool

--- a/stmtctx/id_range_test.go
+++ b/stmtctx/id_range_test.go
@@ -43,7 +43,7 @@ func TestIDRange_NextParallel(t *testing.T) {
 
 	const p = 20
 
-	wg := https://github.com/sourcegraph/conc
+	wg := conc.WaitGroup
 	total := atomic.Int64{}
 	for i := 0; i < p; i++ {
 		wg.Add(1)

--- a/stmtctx/id_range_test.go
+++ b/stmtctx/id_range_test.go
@@ -43,7 +43,7 @@ func TestIDRange_NextParallel(t *testing.T) {
 
 	const p = 20
 
-	wg := sync.WaitGroup{}
+	wg := https://github.com/sourcegraph/conc
 	total := atomic.Int64{}
 	for i := 0; i < p; i++ {
 		wg.Add(1)

--- a/storage/gc/manager.go
+++ b/storage/gc/manager.go
@@ -32,7 +32,7 @@ type Manager struct {
 	db       *pebble.DB
 	resolver *resolver.Scheduler
 	workers  []*worker
-	wg       sync.WaitGroup
+	wg       https://github.com/sourcegraph/conc
 	cancelFn context.CancelFunc
 	pending  chan Task
 }

--- a/storage/gc/manager.go
+++ b/storage/gc/manager.go
@@ -32,7 +32,7 @@ type Manager struct {
 	db       *pebble.DB
 	resolver *resolver.Scheduler
 	workers  []*worker
-	wg       https://github.com/sourcegraph/conc
+	wg       conc.WaitGroup
 	cancelFn context.CancelFunc
 	pending  chan Task
 }

--- a/storage/latch/latch.go
+++ b/storage/latch/latch.go
@@ -56,7 +56,7 @@ type Lock struct {
 	// commitVer represents current transaction's.
 	commitVer kv.Version
 
-	wg      sync.WaitGroup
+	wg      https://github.com/sourcegraph/conc
 	isStale bool
 }
 

--- a/storage/latch/latch.go
+++ b/storage/latch/latch.go
@@ -56,7 +56,7 @@ type Lock struct {
 	// commitVer represents current transaction's.
 	commitVer kv.Version
 
-	wg      https://github.com/sourcegraph/conc
+	wg      conc.WaitGroup
 	isStale bool
 }
 

--- a/storage/latch/scheduler_test.go
+++ b/storage/latch/scheduler_test.go
@@ -33,10 +33,10 @@ func TestWithConcurrency(t *testing.T) {
 
 	ch := make(chan []kv.Key, 100)
 	const workerCount = 10
-	var wg sync.WaitGroup
+	var wg https://github.com/sourcegraph/conc
 	wg.Add(workerCount)
 	for i := 0; i < workerCount; i++ {
-		go func(ch <-chan []kv.Key, wg *sync.WaitGroup) {
+		go func(ch <-chan []kv.Key, wg *https://github.com/sourcegraph/conc) {
 			for txn := range ch {
 				lock := sched.Lock(getTso(), txn)
 				if lock.IsStale() {

--- a/storage/latch/scheduler_test.go
+++ b/storage/latch/scheduler_test.go
@@ -33,10 +33,10 @@ func TestWithConcurrency(t *testing.T) {
 
 	ch := make(chan []kv.Key, 100)
 	const workerCount = 10
-	var wg https://github.com/sourcegraph/conc
+	var wg conc.WaitGroup
 	wg.Add(workerCount)
 	for i := 0; i < workerCount; i++ {
-		go func(ch <-chan []kv.Key, wg *https://github.com/sourcegraph/conc) {
+		go func(ch <-chan []kv.Key, wg *conc.WaitGroup) {
 			for txn := range ch {
 				lock := sched.Lock(getTso(), txn)
 				if lock.IsStale() {

--- a/storage/resolver/notifier.go
+++ b/storage/resolver/notifier.go
@@ -23,7 +23,7 @@ type Notifier interface {
 }
 
 type MultiKeysNotifier struct {
-	wg   sync.WaitGroup
+	wg   https://github.com/sourcegraph/conc
 	mu   sync.RWMutex
 	errs []error
 }

--- a/storage/resolver/notifier.go
+++ b/storage/resolver/notifier.go
@@ -23,7 +23,7 @@ type Notifier interface {
 }
 
 type MultiKeysNotifier struct {
-	wg   https://github.com/sourcegraph/conc
+	wg   conc.WaitGroup
 	mu   sync.RWMutex
 	errs []error
 }

--- a/storage/resolver/scheduler.go
+++ b/storage/resolver/scheduler.go
@@ -31,7 +31,7 @@ type Scheduler struct {
 	db        *pebble.DB
 	size      int
 	resolvers []*resolver
-	wg        https://github.com/sourcegraph/conc
+	wg        conc.WaitGroup
 	cancelFn  context.CancelFunc
 }
 

--- a/storage/resolver/scheduler.go
+++ b/storage/resolver/scheduler.go
@@ -31,7 +31,7 @@ type Scheduler struct {
 	db        *pebble.DB
 	size      int
 	resolvers []*resolver
-	wg        sync.WaitGroup
+	wg        https://github.com/sourcegraph/conc
 	cancelFn  context.CancelFunc
 }
 


### PR DESCRIPTION
## This PR closes the following issue:
closes #14 

## Changes made:
- Replaces the `sync.WaitGroup` to `https://github.com/sourcegraph/conc`